### PR TITLE
Expose "Lint and format" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
 				"command": "dhall.yaml.preview",
 				"title": "dhall-to-yaml preview",
 				"category": "dhall"
+			},
+			{
+				"command": "dhall.lint",
+				"title": "Lint Dhall file",
+				"category": "dhall"
 			}
 		],
 		"menus": {
@@ -77,6 +82,11 @@
 				},
 				{
 					"command": "dhall.yaml.preview",
+					"when": "editorLangId == dhall",
+					"group": "navigation"
+				},
+				{
+					"command": "dhall.lint",
 					"when": "editorLangId == dhall",
 					"group": "navigation"
 				}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 			},
 			{
 				"command": "dhall.lint",
-				"title": "Lint Dhall file",
+				"title": "Lint and format Dhall file",
 				"category": "dhall"
 			}
 		],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,12 +28,12 @@ const outputChannel = window.createOutputChannel("Dhall LSP");
 export async function activate(context: vscode.ExtensionContext) {
 
 	console.log('..Extension "vscode-dhall-lsp-server" is now active..');
-	
+
 	const config = workspace.getConfiguration("vscode-dhall-lsp-server");
 
 	const userDefinedExecutablePath = config.executable;
 
-	let executablePath =  (userDefinedExecutablePath === '') ? 'dhall-lsp-server' : userDefinedExecutablePath; 
+	let executablePath =  (userDefinedExecutablePath === '') ? 'dhall-lsp-server' : userDefinedExecutablePath;
 
 	const executableStatus = await obtainExecutableStatus(executablePath);
 
@@ -50,25 +50,25 @@ export async function activate(context: vscode.ExtensionContext) {
 				window.showErrorMessage('The server executable path is invalid: [' + executablePath + "]");
 			}
 		}
-		
+
 		return;
 	}
 
 	// TODO: properly parse extra arguments!! UNIT TEST !!
 	const logFile: string = config.logFile;
 
-	const logFileOpt : string[] = logFile.trim() === '' ? [] : ['--log=' + logFile]; 
+	const logFileOpt : string[] = logFile.trim() === '' ? [] : ['--log=' + logFile];
 
 
 
-	// let serverCommand = '~/.local/bin/dhall-lsp-server'; // context.asAbsolutePath(path.parse()); 
+	// let serverCommand = '~/.local/bin/dhall-lsp-server'; // context.asAbsolutePath(path.parse());
 	// let serverCommand = context.asAbsolutePath(path.join('/home/vitalii/.local/bin/dhall-lsp-server'));
 
 	let runArgs : string[] = [...logFileOpt];
-	let debugArgs : string[] = [...logFileOpt]; 
+	let debugArgs : string[] = [...logFileOpt];
 
 	let serverOptions: ServerOptions = {
-		run: { command: executablePath, 
+		run: { command: executablePath,
 			   transport: TransportKind.stdio,
 			   args: runArgs
 			 },
@@ -106,7 +106,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	// activate linting command
 	context.subscriptions.push(vscode.commands.registerTextEditorCommand("dhall.lint", (editor, edit) => {
 		const cmd = {
-      		command : "dhall.lint",
+      		command : "dhall.server.lint",
       		arguments: [ editor.document.uri.toString() ] };
 		client.sendRequest('workspace/executeCommand', cmd);
 	}));
@@ -130,13 +130,13 @@ export async function activate(context: vscode.ExtensionContext) {
 async function obtainExecutableStatus(executableLocation: string) : Promise<string> {
   const execPromise =  util.promisify(child_process.execFile)
 							 (executableLocation, ['version'], { timeout: 2000, windowsHide: true })
-							 .then(() => 'available').catch((error) => { 
-								  return 'missing'; 
+							 .then(() => 'available').catch((error) => {
+								  return 'missing';
 								});
   const timeoutPromise : Promise<string> = new Promise((resolve, reject) => {
     let timer = setTimeout(() => {
       clearTimeout(timer);
-      resolve('timedout'); 
+      resolve('timedout');
     }, 1000);
   });
   return Promise.race([execPromise, timeoutPromise]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,6 +103,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	preview.activatePreview('dhall-bash', context.subscriptions);
 	preview.activatePreview('dhall-yaml', context.subscriptions);
 
+	// activate linting command
+	context.subscriptions.push(vscode.commands.registerTextEditorCommand("dhall.lint", (editor, edit) => {
+		const cmd = {
+      		command : "dhall.lint",
+      		arguments: [ editor.document.uri.toString() ] };
+		client.sendRequest('workspace/executeCommand', cmd);
+	}));
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json


### PR DESCRIPTION
Implements the client-side changes needed to make the lint and format command from [dhall-lsp-server](https://github.com/dhall-lang/dhall-haskell/pull/1003) work.