### PR TITLE
Pass client-side configuration on to the server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,11 +82,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	let clientOptions: LanguageClientOptions = {
 		documentSelector: [{ scheme: 'file', language: 'dhall' }],
 		synchronize: {
-      configurationSection: 'vscode-dhall-lsp-server',
+			configurationSection: 'vscode-dhall-lsp-server',
 			// Notify the server about file changes to '.clientrc files contained in the workspace
 			fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
 		},
-    initializationOptions: workspace.getConfiguration("vscode-dhall-lsp-server"),
+		initializationOptions: workspace.getConfiguration("vscode-dhall-lsp-server"),
 		outputChannel: outputChannel
 	};
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,9 @@ export async function activate(context: vscode.ExtensionContext) {
 			// Notify the server about file changes to '.clientrc files contained in the workspace
 			fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
 		},
-		initializationOptions: workspace.getConfiguration("vscode-dhall-lsp-server"),
+    initializationOptions: {
+			'vscode-dhall-lsp-server': workspace.getConfiguration("vscode-dhall-lsp-server")
+		},
 		outputChannel: outputChannel
 	};
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,9 +82,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	let clientOptions: LanguageClientOptions = {
 		documentSelector: [{ scheme: 'file', language: 'dhall' }],
 		synchronize: {
+      configurationSection: 'vscode-dhall-lsp-server',
 			// Notify the server about file changes to '.clientrc files contained in the workspace
 			fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
 		},
+    initializationOptions: workspace.getConfiguration("vscode-dhall-lsp-server"),
 		outputChannel: outputChannel
 	};
 


### PR DESCRIPTION
The LSP provides two means of passing configuration data to the server:

1. As part of the [Initialize Request][initialize] (which is the very
   first message sent to the server) the client can pass arbitrary data
   in the `initializationOptions` field.

2. The protocol specifies
   [didChangeConfiguration][didChangeConfiguration] messages to to
   notify the server of changes changes to the configuration data.

This change uses the `initializationOptions` field to pass the initial
configuration and sets up the vscode lsp client to automatically
synchronise any changes via 2; this way we will be able to use
`haskell-lsp`s [InitializeCallbacks][InitializeCallbacks] mechanism as
intended.

[initialize]: https://microsoft.github.io//language-server-protocol/specifications/specification-3-14/#initialize
[didChangeConfiguration]: https://microsoft.github.io//language-server-protocol/specifications/specification-3-14/#workspace_didChangeConfiguration
[InitializeCallbacks]: https://hackage.haskell.org/package/haskell-lsp-0.15.0.0/docs/Language-Haskell-LSP-Core.html#t:InitializeCallbacks